### PR TITLE
download: Fix alignment of add-on names

### DIFF
--- a/homepage/static/css/custom.css
+++ b/homepage/static/css/custom.css
@@ -207,8 +207,8 @@ a.custom-accordion-title {
     text-decoration: none;
 }
 h3.custom-accordion-title {
-    float: left;
     padding-top: 0;
+    display: inline;
 }
 .custom-accordion-container {
     color: #333;


### PR DESCRIPTION
Names of add-on names are not aligned vertically with versions on download page.

(Chrome 47.0.2526.106, OSX)