### PR TITLE
[FIX] Modified footer layout to avoid left-right scrolling on mobile devices

### DIFF
--- a/homepage/templates/base.html
+++ b/homepage/templates/base.html
@@ -95,7 +95,7 @@
                 <div class="col-md-4 col-sm-6 col-xs-12">
                     <div class="row">
 
-                        <div class="col-xs-4 sitemap-group">
+                        <div class="col-sm-4 sitemap-group">
                             <ul class="links list-sitemap">
                                 <li><b><a class="sitemap-cat" href="/">Orange</a></b></li>
                                 <li><a class="sitemap-sub" href="{% url 'license' %}">License</a></li>
@@ -105,7 +105,7 @@
                             </ul>
                         </div>
 
-                        <div class="col-xs-4 sitemap-group">
+                        <div class="col-sm-4 sitemap-group">
                             <ul class="links list-sitemap">
                                 <li><a class="sitemap-cat" href="{% url 'download' %}">Download</a></li>
                                 <li><a class="sitemap-sub" href="{% url 'download' %}windows/">Windows</a></li>
@@ -114,7 +114,7 @@
                             </ul>
                         </div>
 
-                        <div class="col-xs-4 sitemap-group">
+                        <div class="col-sm-4 sitemap-group">
 
                             <ul class="links list-sitemap">
                                 <li><b><a class="sitemap-cat" href="{% url 'community' %}">Community</a></b></li>
@@ -132,7 +132,7 @@
                 <div class="col-md-3 col-sm-6 col-xs-12">
                     <div class="row">
 
-                        <div class="col-xs-6 sitemap-group docs-devs">
+                        <div class="col-sm-6 sitemap-group docs-devs">
                             <ul class="links list-sitemap">
                                 <li><a class="sitemap-cat" href="{% url 'docs' %}">Documentation</a></li>
                                 <li><a class="sitemap-sub" href="{% url 'start' %}">Get started</a></li>
@@ -141,7 +141,7 @@
                             </ul>
                         </div>
 
-                        <div class="col-xs-6 sitemap-group">
+                        <div class="col-sm-6 sitemap-group">
                             <ul class="links list-sitemap">
                                 <li><b><a class="sitemap-cat" href="https://github.com/biolab/orange3">Developers</a></b></li>
                                 <li><a class="sitemap-sub" href="https://github.com/biolab/orange3">GitHub</a></li>


### PR DESCRIPTION
Problem was that tweeter link (@OrangeDataMiner) was too long when 3 columns one beside other appeared on screen with width less than cca. 450px what resulted in left-right scrolling on many mobiles devices. 

I solved problem with setting each column in new line when size is xs. To make same design for the next part (Documentation, Developers) I also set same property for this part. 

