### PR TITLE
Modified margins on homepages when small size of screen

### DIFF
--- a/homepage/static/css/custom.css
+++ b/homepage/static/css/custom.css
@@ -482,3 +482,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     display: block;
     line-height: 1.5em;
 }
+.nopadding {
+   padding: 0 !important;
+   margin: 0 !important;
+}

--- a/homepage/templates/feature_panel.html
+++ b/homepage/templates/feature_panel.html
@@ -1,9 +1,9 @@
 {% block feature_panel %}
 
     <div class="feature-panel row">
-        <div class="content col-sm-1 pull-left"></div>
-        <div class="content col-sm-1 pull-right"></div>
-        <div class="content col-sm-5 col-xs-12 feature-description panel-left pull-{% if not index|divisibleby:2 %}left{% else %}right{% endif %}">
+        <div class="content col-md-1 pull-left nopadding"></div>
+        <div class="content col-md-1 pull-right nopadding"></div>
+        <div class="content col-md-5 col-sm-6 col-xs-12 feature-description panel-left pull-{% if not index|divisibleby:2 %}left{% else %}right{% endif %}">
             <h2 class="feature-title">{{ feature.title }}</h2>
             <p class="feature-text">{{ feature.description }}</p>
             <div class="more">
@@ -26,7 +26,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="content col-sm-5 col-xs-12 feature-image {% if not index|divisibleby:2 %}{% else %}panel-left{% endif %}">
+        <div class="content col-md-5 col-sm-6 col-xs-12 feature-image {% if not index|divisibleby:2 %}{% else %}panel-left{% endif %}">
             <img class="image {% if not index|divisibleby:2 %}right{% else %}left{% endif %}" src="{{ feature.image_link }}">
         </div>
 

--- a/homepage/templates/testimonials.html
+++ b/homepage/templates/testimonials.html
@@ -2,7 +2,7 @@
     <div class="row testimonial-list">
         <h2 class="feature-title col-xs-12">User Testimonials</h2>
         {% for testimonial in testimonials %}
-            <div class="content col-sm-4 col-xs-12 item">
+            <div class="content col-md-4 col-sm-12 item">
                 <div class="img-container">
                     <img src="{{ testimonial.img }}">
                 </div>


### PR DESCRIPTION
With this pull request we modified margins of feature panels when small to get wider view and put user testimonials in one column when small screen. Before columns width was too small. 