### PR TITLE
Use python2 instead of python (PEP394)

### DIFF
--- a/homepage/templates/download_source.html
+++ b/homepage/templates/download_source.html
@@ -7,8 +7,8 @@
 
 <h3>setup.py</h3>
 <p>To build and install Orange you can use the setup.py in the root orange directory (requires GCC, Python and numpy development headers). To use it unpack the nightly sources and run:</p>
-<pre>python setup.py build<br>sudo python setup.py install</pre>
+<pre>python2 setup.py build<br>sudo python2 setup.py install</pre>
 <p>This will also install orange-canvas script so you can start Orange Canvas from the command line.</p>
 <p>To install orange locally run:</p>
-<pre>python setup.py install --user</pre>
+<pre>python2 setup.py install --user</pre>
 <p>This will install orange in /home/&lt;username&gt;/.local/lib/pythonX.Y/site-packages/orange/.</p>


### PR DESCRIPTION
Yes always use py2 in orange css