### PR TITLE
[FIX] Removed old version info on the home page.

### DIFF
--- a/homepage/templates/homepage.html
+++ b/homepage/templates/homepage.html
@@ -43,9 +43,11 @@
                             </a>
                             {% endcomment %}
 
+                            {% comment %}
 							<div class="content">
                                 <p style="margin-top:6px">The <a id="orange2-link" href="/orange2/">old version</a>, Orange 2.7, is still available.</p>
                             </div><!--//content-->
+                            {% endcomment %}
                     </div>
 
                 </div><!--//overview-->


### PR DESCRIPTION
Removed the line "The old version, Orange 2.7, is still available." from the home page.