### PR TITLE
Add GA tracking for Donate button

### DIFF
--- a/homepage/templates/base.html
+++ b/homepage/templates/base.html
@@ -78,7 +78,7 @@
                         <li class="nav-item"><a id="header-docs-link" href="{% url 'docs' %}">Docs</a></li>
                         <li class="nav-item"><a id="header-blog-link" href="https://blog.biolab.si">Blog</a></li>
                         <li class="nav-item">
-                            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+                            <form onclick="ga('send', 'event', 'Donate', 'click', 'paypal');" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
                             <input type="hidden" name="cmd" value="_s-xclick">
                             <input type="hidden" name="hosted_button_id" value="HCTE45LJ7YDJA">
                                 <input type="submit" value="Donate" name="submit" title="Support Orange team with ice cream! :)" class="btn btn-lg navbar" id="donate">


### PR DESCRIPTION
Tentative solution to GA tracking.
Sourced from: [stackoverflow](https://stackoverflow.com/questions/35304248/how-do-i-track-a-paypal-button-click-using-google-analytics-event-triggars)