### PR TITLE
Update Django to 1.8.18

### DIFF
--- a/orange_web/settings.py
+++ b/orange_web/settings.py
@@ -32,7 +32,7 @@ RECAPTCHA_SECRET = 'get the string from Google'
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-ALLOWED_HOSTS = ['orange.biolab.si', 'new.orange.biolab.si']
+ALLOWED_HOSTS = ['orange.biolab.si', 'new.orange.biolab.si', '127.0.0.1']
 
 BLOG_HOST = 'blog.biolab.si'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.6.2
+django==1.8.18
 feedparser==5.1.3
 logilab-common==0.61.0
 pep8==1.5.5


### PR DESCRIPTION
Closes #99 

The upgrade to Django 1.8.18 seems relatively straightforward. Please review.

# Changes
- bump Django version to 1.8.18
- add 127.0.0.1 to [ALLOWED_HOSTS](https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts) in settings.py