### PR TITLE
Remove link to deprecated installation instructions.

### DIFF
--- a/homepage/templates/start.html
+++ b/homepage/templates/start.html
@@ -16,8 +16,7 @@
                         <h3 class="custom-reduce-padding">Download and Install</h3>
                         <p>
                             <a href="{% url 'download' %}">Download</a> Orange distribution package and run the
-                            installation file on your local computer. <a href="http://biolab.github.io/datafusion-installation-guide/">
-                            Here</a> is a step-by-step installation guide, that we recommend you to follow.
+                            installation file on your local computer.
                         </p>
                         <h3>Run</h3>
                         <p>


### PR DESCRIPTION
Link to old installation instructions removed not to mislead users.