### PR TITLE
Catch exceptions during failure in name resolution.

### DIFF
--- a/homepage/templatetags/tag_extras.py
+++ b/homepage/templatetags/tag_extras.py
@@ -28,8 +28,12 @@ def grab_feed_all():
     rss_feed = 'https://blog.biolab.si/feed/'
     try:
       resp = requests.get(rss_feed, timeout=3.0)
-    except requests.ReadTimeout:
+    except requests.exceptions.ReadTimeout:
       logger.warn("Timeout when reading RSS %s", rss_feed)
+      return
+    except requests.exceptions.ConnectionError:
+      # This problem may be caused by bad DNS server
+      logger.warn("Connection error when reading RSS %s", rss_feed)
       return
 
     # Put it to memory stream object universal feedparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Pillow==4.0.0
 pylint
 pytz==2017.2
 raven>=6.3.0
-requests
+requests==2.19.1
 six
 wrapt==1.10.8
 certifi


### PR DESCRIPTION
Problem: Bad DNS server causes exceptions and website crash.

Changes:
- Fix incorrect ReadTimeout exception call.
- Catch ConnectionError when it occurs.
- Freeze requests version to avoid future changes in module structure.