### PR TITLE
Catch ConnectionError in tag_extras.py.

### DIFF
--- a/homepage/templatetags/tag_extras.py
+++ b/homepage/templatetags/tag_extras.py
@@ -31,6 +31,10 @@ def grab_feed_all():
     except requests.ReadTimeout:
       logger.warn("Timeout when reading RSS %s", rss_feed)
       return
+    except requests.exceptions.ConnectionError:
+      # This problem may be caused by bad DNS server
+      logger.warn("Connection error when reading RSS %s", rss_feed)
+      return
 
     # Put it to memory stream object universal feedparser
     content = BytesIO(resp.content)


### PR DESCRIPTION
Problem: Bad DNS server causes exceptions and website crash. 
Fix: Catch ConnectionError when it occurs.
