### PR TITLE
Remove Miniconda 32-bit download link.

### DIFF
--- a/download/templates/download/windows.html
+++ b/download/templates/download/windows.html
@@ -10,7 +10,6 @@
 
     <h3><a id="standalone"></a>Miniconda installer (Default)</h3>
     <a href="{{ miniconda.url }}">{{ miniconda.filename }} (64 bit)</a><br />
-    <a href="{{ miniconda32.url }}">{{ miniconda32.filename }} (32 bit)</a>
     <p>
         Installs Miniconda and Orange. Can be used without administrator privileges.
     </p>


### PR DESCRIPTION
conda-forge dropped support for 32-bit installers.