### PR TITLE
Orange 2: update links

### DIFF
--- a/download/templates/download/orange2.html
+++ b/download/templates/download/orange2.html
@@ -13,9 +13,9 @@
                 <div class="content">
                     <p>Orange 2.7 is a legacy version of Orange. We think you should upgrade to the <a href="/download">current version</a>, but if you still need the version 2.7, please download it below.</p>
 
-                    <p>Windows: <a href="http://orange.biolab.si/download/files/archive/orange-win-w-python-snapshot-hg-2016-06-17-py2.7.exe">Orange 2.7 installer for Windows.</a></p>
-                    <p>Mac OS: <a href="http://orange.biolab.si/download/files/archive/Orange-2.7.8-440e21.dmg">Orange 2.7 bundle for OSX.</a></p>
-                    <p>Other systems: <a href="http://orange.biolab.si/download/files/archive/orange-source-snapshot-hg-2016-06-17.zip">Orange 2.7 source.</a></p>
+                    <p>Windows: <a href="https://orange.biolab.si/download/files/archive/orange-win-w-python-snapshot-hg-2016-06-17-py2.7.exe">Orange 2.7 installer for Windows.</a></p>
+                    <p>Mac OS: <a href="https://orange.biolab.si/download/files/archive/Orange-2.7.8-440e21.dmg">Orange 2.7 bundle for OSX.</a></p>
+                    <p>Other systems: <a href="https://orange.biolab.si/download/files/archive/orange-source-snapshot-hg-2016-06-17.zip">Orange 2.7 source.</a></p>
 
                 </div>
             </div>


### PR DESCRIPTION
Hard code https links for Orange 2 download, since the old ones cause redirect issues.